### PR TITLE
Small bux fixes

### DIFF
--- a/src/generated/resources/data/tutorial/loot_tables/blocks/demo.json
+++ b/src/generated/resources/data/tutorial/loot_tables/blocks/demo.json
@@ -28,15 +28,6 @@
                   "op": "replace"
                 }
               ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "tutorial:demo"

--- a/src/generated/resources/data/tutorial/loot_tables/blocks/generator.json
+++ b/src/generated/resources/data/tutorial/loot_tables/blocks/generator.json
@@ -28,15 +28,6 @@
                   "op": "replace"
                 }
               ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "tutorial:generator"

--- a/src/main/java/com/mcjty/blocks/DemoBlock.java
+++ b/src/main/java/com/mcjty/blocks/DemoBlock.java
@@ -1,8 +1,10 @@
 package com.mcjty.blocks;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
@@ -34,6 +36,20 @@ public class DemoBlock extends Block implements EntityBlock {
         return new DemoBE(pos, state);
     }
 
+    @Override
+    public void setPlacedBy(Level pLevel, BlockPos pPos, BlockState pState, @Nullable LivingEntity pPlacer, ItemStack pStack) {
+        super.setPlacedBy(pLevel, pPos, pState, pPlacer, pStack);
+        if (pStack.hasTag()) {
+            CompoundTag blockEntityTag = pStack.getTag().getCompound("BlockEntityTag");
+
+            if (!pLevel.isClientSide && !blockEntityTag.isEmpty()) {
+                BlockEntity blockEntity = pLevel.getBlockEntity(pPos);
+                if (blockEntity instanceof DemoBE demoBE) {
+                    demoBE.load(blockEntityTag);
+                }
+            }
+        }
+    }
     @Override
     public void appendHoverText(ItemStack stack, @Nullable BlockGetter reader, List<Component> list, TooltipFlag flags) {
         list.add(new TranslatableComponent("message.demo.tooltip"));

--- a/src/main/java/com/mcjty/blocks/GeneratorBE.java
+++ b/src/main/java/com/mcjty/blocks/GeneratorBE.java
@@ -101,6 +101,12 @@ public class GeneratorBE extends BlockEntity {
     }
 
     @Override
+    public void handleUpdateTag(CompoundTag tag) {
+        //No Op
+        // We do not want to call load with a tag that doesn't have the information to be loaded
+    }
+
+    @Override
     public void load(CompoundTag tag) {
         itemHandler.deserializeNBT(tag.getCompound("inv"));
         energyStorage.deserializeNBT(tag.get("energy"));

--- a/src/main/java/com/mcjty/blocks/GeneratorBlock.java
+++ b/src/main/java/com/mcjty/blocks/GeneratorBlock.java
@@ -1,12 +1,16 @@
 package com.mcjty.blocks;
 
+import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -60,6 +64,20 @@ public class GeneratorBlock extends Block implements EntityBlock {
         }
     }
 
+    @Override
+    public void setPlacedBy(Level pLevel, BlockPos pPos, BlockState pState, @Nullable LivingEntity pPlacer, ItemStack pStack) {
+        super.setPlacedBy(pLevel, pPos, pState, pPlacer, pStack);
+        if (pStack.hasTag()) {
+            CompoundTag blockEntityTag = pStack.getTag().getCompound("BlockEntityTag");
+
+            if (!pLevel.isClientSide && !blockEntityTag.isEmpty()) {
+                BlockEntity blockEntity = pLevel.getBlockEntity(pPos);
+                if (blockEntity instanceof GeneratorBE generatorBE) {
+                    generatorBE.load(blockEntityTag);
+                }
+            }
+        }
+    }
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(BlockStateProperties.FACING, BlockStateProperties.POWERED);

--- a/src/main/java/com/mcjty/blocks/GeneratorBlock.java
+++ b/src/main/java/com/mcjty/blocks/GeneratorBlock.java
@@ -68,7 +68,9 @@ public class GeneratorBlock extends Block implements EntityBlock {
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        return defaultBlockState().setValue(BlockStateProperties.FACING, context.getNearestLookingDirection().getOpposite());
+        return defaultBlockState()
+                .setValue(BlockStateProperties.FACING, context.getNearestLookingDirection().getOpposite())
+                .setValue(BlockStateProperties.POWERED,false);
     }
 
     @Override

--- a/src/main/java/com/mcjty/datagen/LootTables.java
+++ b/src/main/java/com/mcjty/datagen/LootTables.java
@@ -53,8 +53,6 @@ public class LootTables extends LootTableProvider {
                         .apply(CopyNbtFunction.copyData(ContextNbtProvider.BLOCK_ENTITY)
                                 .copy("inv", "BlockEntityTag.inv", CopyNbtFunction.MergeStrategy.REPLACE)
                                 .copy("energy", "BlockEntityTag.energy", CopyNbtFunction.MergeStrategy.REPLACE))
-                        .apply(SetContainerContents.setContents()
-                                .withEntry(DynamicLoot.dynamicEntry(new ResourceLocation("minecraft", "contents"))))
                 );
         return LootTable.lootTable().withPool(builder);
     }


### PR DESCRIPTION
This PR adds three small bug fixes.

1.  Restores block NBT when the item is placed back down.
2.  Sets the default block state of a placed generator to not be powered.
3.  Removes the mincraft:set_contents loottable function as it adds unnecessary/unused nbt to the item.